### PR TITLE
My new work branch

### DIFF
--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -126,6 +126,9 @@ REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": (
         "rest_framework_simplejwt.authentication.JWTAuthentication",
     ),
+    "DEFAULT_PERMISSION_CLASSES": (
+        "rest_framework.permissions.IsAuthenticated",
+    ),
 }
 
 SIMPLE_JWT = {

--- a/src/tickets/permissions.py
+++ b/src/tickets/permissions.py
@@ -4,6 +4,7 @@ from rest_framework.permissions import BasePermission
 
 from tickets.models import Ticket
 from users.constants import Role
+from users.models import User
 
 
 class RoleIsAdmin(BasePermission):
@@ -18,6 +19,17 @@ class RoleIsManager(BasePermission):
 
     def has_permission(self, request, view):
         return request.user.role == Role.MANAGER  # type: ignore
+
+
+class IsManager(BasePermission):
+    """
+    Class that grants, only allow managers to be assigned to tickets.
+    """
+
+    def has_permission(self, request, view):
+        new_manager_id = request.data.get("new_manager")
+        manager = User.objects.get(id=new_manager_id)
+        return manager.role == Role.MANAGER  # type: ignore
 
 
 class RoleIsUser(BasePermission):

--- a/src/tickets/serializers.py
+++ b/src/tickets/serializers.py
@@ -2,7 +2,7 @@
 
 from rest_framework import serializers
 
-from tickets.models import Ticket
+from tickets.models import Message, Ticket
 
 
 class TicketSerializer(serializers.ModelSerializer):
@@ -30,3 +30,12 @@ class TicketAssignSerializer(serializers.Serializer):
         ticket.save()
 
         return ticket
+
+
+class MessageSerializer(serializers.ModelSerializer):
+    user = serializers.HiddenField(default=serializers.CurrentUserDefault())
+
+    class Meta:
+        model = Message
+        fields = ["id", "text", "user", "ticket", "timestamp"]
+        read_only_fields = ["id", "timestamp"]


### PR DESCRIPTION
Reassign function updated, now Admin can reassign the Ticket only if User is Manager.
- Request body has only one value - new manager id.
- New permission class (IsManager) added, reassign is possible if user is manager.
In the project added new API endpoint /tickets/{id}/messages/ with two methods GET & POST to get and create messages from Users and Managers.
- Request body has only one value - message text, other fields are defined by themselves.
- Users & Managers can only see messages that are attached to them.